### PR TITLE
Corrected datatype for sunssFiberId (U4) and MTP column names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@
 .sconsign.dblite
 python/pfs/utils/version.py
 bin/*
+tests/.tests
+.coverage
+.pytest_cache
+pytest_session.txt
+

--- a/python/pfs/utils/constants.py
+++ b/python/pfs/utils/constants.py
@@ -1,0 +1,9 @@
+"""General PFS engineering constants
+"""
+N_SPECTROGRAPHS = 4  # Number of spectrographs
+FIBERS_PER_SPECTROGRAPH = 651  # Number of fibers per spectrograph
+N_FIELDS_PFI = 3  # Number of fields in the PFI
+N_MODULES_PER_FIELD = 14  # Number of modules in a PFI field
+N_COBRAS_PER_MODULE = 57  # Maxmimum number of cobras in a given module.
+N_COBRAS_PER_MTP = 42  # Number of cobras per MTP ferrule.
+N_MTP_FERRULES = 2  # Number of MTP ferrules per module

--- a/python/pfs/utils/fiberids.py
+++ b/python/pfs/utils/fiberids.py
@@ -4,6 +4,7 @@ import os
 
 import eups
 
+
 class FiberIds(object):
     """ Track all fiber ids and positions.
 
@@ -44,6 +45,11 @@ class FiberIds(object):
     fiducials? Separate class, probably.
     Identify engineering/blank holes?
     """
+
+    # When reading in the grand fiber map, missing
+    # values for integer fields
+    # are assigned this
+    MISSING_VALUE = 65535
 
     def __init__(self, path=None):
         if path is None:
@@ -87,14 +93,42 @@ class FiberIds(object):
                  ('fiberHoleId', 'u2'),
                  ('scienceFiberId', 'u2'),
                  ('fiberId', 'u2'),
-                 ('sunssFiberId', 'u2'),
-                 ('USCONNECMTPAId', 'U15'),
-                 ('USCONNECMTPCId', 'U15'),
-                 ('USCONNECMTPBAId', 'U15'),
-                 ('USCONNECMTPBCId', 'U15'),
+                 ('sunssFiberId', 'U4'),
+                 ('mtp_A', 'U15'),
+                 ('mtp_C', 'U15'),
+                 ('mtp_BA', 'U15'),
+                 ('mtp_BC', 'U15'),
                  ]
 
+        # Read in data from grand fiber map text file
+        #
+        # Note that providing an explicit list of fill values
+        # rather than the default so that they can be checked in the unit test.
+        # For string fields original value needs to be propagated.
+        # To do that, using filling_value of np.nan
+        # to instruct np.genfromtxt to just propagate the literal field value.
         self.data = np.genfromtxt(flist[0], dtype=dtype,
+                                  filling_values=[self.MISSING_VALUE,
+                                                  self.MISSING_VALUE,
+                                                  self.MISSING_VALUE,
+                                                  self.MISSING_VALUE,
+                                                  self.MISSING_VALUE,
+                                                  self.MISSING_VALUE,
+                                                  self.MISSING_VALUE,
+                                                  self.MISSING_VALUE,
+                                                  np.nan,
+                                                  np.nan,
+                                                  np.nan,
+                                                  np.nan,
+                                                  self.MISSING_VALUE,
+                                                  self.MISSING_VALUE,
+                                                  self.MISSING_VALUE,
+                                                  self.MISSING_VALUE,
+                                                  np.nan,
+                                                  np.nan,
+                                                  np.nan,
+                                                  np.nan,
+                                                  np.nan],
                                   comments='\\')
         for name in [d[0] for d in dtype]:
             def _fetchOne(self, name=name):

--- a/python/pfs/utils/fibers.py
+++ b/python/pfs/utils/fibers.py
@@ -1,6 +1,6 @@
-__all__ = ("FIBERS_PER_SPECTROGRAPH", "calculateFiberId", "spectrographFromFiberId", "fiberHoleFromFiberId")
+from pfs.utils.constants import FIBERS_PER_SPECTROGRAPH
 
-FIBERS_PER_SPECTROGRAPH = 651  # Number of fibers per spectrograph
+__all__ = ("FIBERS_PER_SPECTROGRAPH", "calculateFiberId", "spectrographFromFiberId", "fiberHoleFromFiberId")
 
 
 def calculateFiberId(spectrograph, fiberHole):

--- a/tests/SConscript
+++ b/tests/SConscript
@@ -1,0 +1,4 @@
+# -*- python -*-
+from lsst.sconsUtils import scripts
+scripts.BasicSConscript.tests(pyList=[])
+

--- a/tests/test_fiberIds.py
+++ b/tests/test_fiberIds.py
@@ -1,0 +1,214 @@
+import unittest
+import numpy as np
+import re
+from pfs.utils.fiberids import FiberIds
+from pfs.utils import constants
+from pfs.utils.fibpacking import N_PER_FERRULE
+
+
+class FiberIdsTestCase(unittest.TestCase):
+
+    MISSING_VALUE = FiberIds.MISSING_VALUE
+
+    # Derive the total number of slit holes in the PFS
+    TOTAL_NUMBER_SLIT_HOLES = (constants.N_SPECTROGRAPHS *
+                               constants.FIBERS_PER_SPECTROGRAPH)
+
+    MTP_REGEX = re.compile(r'(U\d|EN|D\d)-(\d)-(\d)-(\d+)-(x|\d+)')
+
+    def testCreation(self):
+        """Checks that FiberId object is correctly
+        instantiated from grand fiber map
+        and basic sanity checks are applied
+        to accessor methods.
+        """
+
+        fbi = FiberIds()
+
+        # Check number of columns in grand fiber map are as expected
+        self.assertEqual(len(fbi.data.dtype), 21)
+
+        # And the number of rows
+        # FIXME: currently this is 6 fewer than expected.
+        # This will be fixed in INSTRM-1260
+        # self.assertEqual(fbi.data.shape[0], TOTAL_NUMBER_FIBERS)
+        self.assertEqual(fbi.data.shape[0], self.TOTAL_NUMBER_SLIT_HOLES - 6)
+
+        # Check properties are accessible
+        for name in fbi.data.dtype.names:
+            getattr(fbi, name)
+
+        # Check cobraIds
+        cobraId = fbi.cobraId[fbi.cobraId != self.MISSING_VALUE]
+        self.assertTrue(len(np.unique(cobraId)) == len(cobraId))
+        self.assertEqual(min(cobraId), 1)
+        self.assertEqual(max(cobraId), 2394)
+
+        # Check fieldId
+        fieldId = fbi.fieldId[fbi.fieldId != self.MISSING_VALUE]
+        self.assertEqual(min(fieldId), 1)
+        self.assertEqual(max(fieldId), constants.N_FIELDS_PFI)
+
+        # Check cobraInFieldId
+        print(f'fbi.cobraInFieldId {fbi.cobraInFieldId}')
+        cobraInFieldId = fbi.cobraInFieldId[fbi.cobraInFieldId
+                                            != self.MISSING_VALUE]
+        self.assertEqual(min(cobraInFieldId), 1)
+        self.assertEqual(max(cobraInFieldId),
+                         constants.N_MODULES_PER_FIELD *
+                         constants.N_COBRAS_PER_MODULE)
+
+        # Check cobraModuleId
+        cobraModuleId = fbi.cobraModuleId[fbi.cobraModuleId
+                                          != self.MISSING_VALUE]
+        self.assertEqual(min(cobraModuleId), 1)
+        self.assertEqual(max(cobraModuleId),
+                         constants.N_FIELDS_PFI *
+                         constants.N_MODULES_PER_FIELD)
+
+        # Check moduleInFieldId
+        moduleInFieldId = fbi.moduleInFieldId[fbi.moduleInFieldId
+                                              != self.MISSING_VALUE]
+        self.assertEqual(min(moduleInFieldId), 1)
+        self.assertEqual(max(moduleInFieldId), constants.N_MODULES_PER_FIELD)
+
+        # Check cobraInModuleId
+        cobraInModuleId = fbi.cobraInModuleId[fbi.cobraInModuleId
+                                              != self.MISSING_VALUE]
+        self.assertEqual(min(cobraInModuleId), 1)
+        self.assertEqual(max(cobraInModuleId), constants.N_COBRAS_PER_MODULE)
+
+        # Check that (cobraModuleId, cobraInModuleId) is unique
+        for module in range(constants.N_FIELDS_PFI
+                            * constants.N_MODULES_PER_FIELD):
+            for cobraInModule in range(constants.N_COBRAS_PER_MODULE):
+                cobraIdsInCombo = cobraId[np.logical_and(
+                                          cobraModuleId == module,
+                                          cobraInModuleId == cobraInModule)]
+                self.assertEqual(len(np.unique(cobraIdsInCombo)),
+                                 len(cobraIdsInCombo),
+                                 msg=f'For module={module} '
+                                     f'and cobraInModule={cobraInModule}: '
+                                     f'cobraIds are not unique. '
+                                     f'cobraIds = {cobraIdsInCombo}')
+
+        # Check cobraInFieldId in more detail
+        expectedCobraInFieldId = ((moduleInFieldId-1) *
+                                  constants.N_COBRAS_PER_MODULE +
+                                  cobraInModuleId)
+        np.testing.assert_array_equal(cobraInFieldId, expectedCobraInFieldId)
+
+        # Check cobraInBoardId
+        cobraInBoardId = fbi.cobraInBoardId[fbi.cobraInBoardId
+                                            != self.MISSING_VALUE]
+        self.assertEqual(min(cobraInBoardId), 1)
+        self.assertTrue(max(cobraInBoardId)
+                        in [23, 29])
+
+        # Check boardId
+        boardId = fbi.boardId[fbi.boardId
+                              != self.MISSING_VALUE]
+        self.assertEqual(min(boardId), 1)
+        self.assertEqual(max(boardId),
+                         constants.N_COBRAS_PER_MTP *
+                         constants.N_MTP_FERRULES)
+
+        # Check cobraModuleIdInMTP
+        cobraModuleIdInMtpA = []
+        cobraModuleIdInMtpB = []
+        expectedMtp = ['A', 'B']
+        for cm in fbi.cobraModuleIdInMTP:
+            if cm == '-':
+                continue
+            mtp = cm[-1]
+            self.assertTrue(mtp in expectedMtp,
+                            f"MTP '{mtp}' of cobraModuleInMtp '{cm}'"
+                            f" is not one of the expected ones of"
+                            f" {expectedMtp}")
+            mtpId = int(cm[:-1])
+            if mtp == 'A':
+                cobraModuleIdInMtpA.append(mtpId)
+            else:
+                cobraModuleIdInMtpB.append(mtpId)
+
+        self.assertEqual(min(cobraModuleIdInMtpA), 1)
+        self.assertEqual(max(cobraModuleIdInMtpA), constants.N_COBRAS_PER_MTP)
+        self.assertEqual(min(cobraModuleIdInMtpB), 1)
+        self.assertEqual(max(cobraModuleIdInMtpB), constants.N_COBRAS_PER_MTP)
+
+        # Check x, y
+        # Assume PFI region is a hexagon with vertices
+        # [(0, 224), (194, 112),
+        # (194, -112), (0, -224),
+        # (-194, -112), (-194, 112)]
+        x = fbi.x[~np.isnan(fbi.x)]
+        y = fbi.y[~np.isnan(fbi.y)]
+
+        # Map coordinates to positive quadrant to simplify check
+        inRegion = np.logical_and(np.absolute(x) < 194.0,
+                                  np.absolute(y) <= -(112.0/194.0)*x + 224.0)
+        badPoints = [(x_i, y_i)
+                     for x_i, y_i in zip(x[~inRegion],
+                                         y[~inRegion])]
+        self.assertTrue(np.all(inRegion),
+                        msg="Points with coordinates"
+                            f"{badPoints}"
+                            f" are outside PFI hexagon."
+                        )
+
+        # Check rad (rad^2 = x^2 + y^2)
+        rad = fbi.rad[~np.isnan(fbi.rad)]
+        self.assertEqual(len(rad), len(x))
+        self.assertEqual(len(rad), len(y))
+        # Note: tolerance for this test is very low,
+        # but the precision of x and y are very low
+        np.testing.assert_allclose(np.square(rad),
+                                   np.square(x) + np.square(y),
+                                   rtol=1.0, atol=0)
+
+        # Check spectrographId
+        self.assertEqual(min(fbi.spectrographId), 1)
+        self.assertEqual(max(fbi.spectrographId),
+                         constants.N_SPECTROGRAPHS)
+
+        # Check fiberId
+        self.assertEqual(min(fbi.fiberId), 1)
+        self.assertEqual(max(fbi.fiberId), self. TOTAL_NUMBER_SLIT_HOLES)
+
+        # Check SuNSS fiber IDs
+        sunssImagingFibers = []
+        sunssDiffuseFibers = []
+        for sfi in fbi.sunssFiberId[fbi.sunssFiberId != 'emp']:
+
+            instrument = sfi[0]
+
+            expectedSunssInstruments = ['i', 'd']
+            self.assertTrue(instrument in expectedSunssInstruments,
+                            f"SuNSS instrument '{instrument}'"
+                            f" is not one of the expected ones of"
+                            f" {expectedSunssInstruments}")
+
+            fiberId = int(sfi[1:])
+            if instrument == 'i':
+                sunssImagingFibers.append(fiberId)
+            else:
+                sunssDiffuseFibers.append(fiberId)
+
+        self.assertEqual(min(sunssImagingFibers), 1)
+        self.assertEqual(max(sunssImagingFibers),
+                         N_PER_FERRULE)
+        self.assertEqual(min(sunssDiffuseFibers), 1)
+        self.assertEqual(max(sunssDiffuseFibers),
+                         N_PER_FERRULE)
+
+        # Check MTP values
+        for field, mtps in zip(['A', 'PC', 'BA', 'BC'],
+                               [fbi.mtp_A, fbi.mtp_C,
+                                fbi.mtp_BA, fbi.mtp_BC]):
+            for mtp in mtps:
+                if mtp == '-':
+                    continue
+                self.assertTrue(self.MTP_REGEX.match(mtp),
+                                msg=f"MTP value '{mtp}'"
+                                    f" in column 'mtp_{field}'"
+                                    " does not match expected pattern.")


### PR DESCRIPTION
The MTP property names have been simplified to mtp_A etc.

Also added a unit test to check the loading
of the grand fiber map data and expected
ranges of the data.

In addition added a separate file to store useful
engineering constants.