### PR TITLE
allow arbitrary length string for obCode

### DIFF
--- a/python/pfs/utils/pfsDesignUtils.py
+++ b/python/pfs/utils/pfsDesignUtils.py
@@ -163,7 +163,7 @@ def makePfsDesign(pfiNominal, ra, dec,
     parallax = setDefaultValues(sciVal=parallax, engVal=1.0e-8, dtype="float32")
 
     proposalId = setDefaultValues(sciVal=proposalId, engVal="N/A", dtype="U32")
-    obCode = setDefaultValues(sciVal=obCode, engVal="N/A", dtype="U32")
+    obCode = setDefaultValues(sciVal=obCode, engVal="N/A", dtype=object)  # string with arbitrary lengths
 
     # I might be overaccommodating here but ...
     if filterNames is None:


### PR DESCRIPTION
`obCode` in `pfsDesign`/`pfsConfig` can be longer than 32 characters and I would like to set the `dtype` as `object` to allow strings with arbitrary lengths. 
