### PR TITLE
Move the location of importing the eups package

### DIFF
--- a/python/pfs/utils/fiberids.py
+++ b/python/pfs/utils/fiberids.py
@@ -1,7 +1,6 @@
 import glob
 import os
 
-import eups
 import numpy as np
 
 
@@ -54,6 +53,7 @@ class FiberIds(object):
 
     def __init__(self, path=None):
         if path is None:
+            import eups
             path = os.path.join(eups.productDir('PFS_UTILS'),
                                 'data', 'fiberids')
         self.filepath = 'unset'


### PR DESCRIPTION
fiberids.py in python/pfs/utils/ in pfs_uitls imports eups at the top section, but it is only used to look up the PFS_UTILS parameter using eups.productDir('PFS_UTILS'). As the constructor of FiberIds allows to be called with a path to the fiberid data directory, it would be nice if the import line is moved right above the line using eups to minimize the dependency to eups for Python environments not using it. This commit enables it.

I've checked that the commit successfully passed the scons unit tests and the integration test.