### PR TITLE
Create common SUBARU EarthLocation - tickets/INSTRM-2623

### DIFF
--- a/python/pfs/utils/coordinates/CoordTransp.py
+++ b/python/pfs/utils/coordinates/CoordTransp.py
@@ -8,8 +8,7 @@ from scipy import interpolate as ipol
 
 from astropy import units as u
 from astropy.time import Time
-from astropy.coordinates import SkyCoord, EarthLocation, AltAz
-from astroplan import Observer
+from astropy.coordinates import SkyCoord, AltAz
 import astropy.coordinates as ascor
 
 from scipy.spatial.transform import Rotation as R
@@ -25,6 +24,7 @@ from scipy.spatial.transform import Rotation as R
 
 from . import DistortionCoefficients as DCoeff
 from . import Subaru_POPT2_PFS
+from pfs.utils.location import SUBARU
 
 mypath = os.path.dirname(os.path.abspath(__file__))+'/'
 
@@ -225,7 +225,7 @@ def convert_out_position(x, y, inr, c, cent, time, za):
                                   DCoeff.wl_ag, time)
     elif c.mode == 'pfi_sky_old':  # WFC to Ra-Dec
         # Set Observation Site (Subaru)
-        tel = EarthLocation.of_site('Subaru')
+        tel = SUBARU.location
         obs_time = Time(time)
 
         aref_file = mypath+'data/Refraction_data_635nm.txt'

--- a/python/pfs/utils/coordinates/Subaru_POPT2_PFS.py
+++ b/python/pfs/utils/coordinates/Subaru_POPT2_PFS.py
@@ -5,6 +5,8 @@ import astropy.units as au
 import astropy.time as at
 import astropy.coordinates as ac
 
+from pfs.utils.location import SUBARU
+
 ### unknown scale factor
 Unknown_Scale_Factor_AG = 1.0 + 6.2e-04 # focus offset glass added 20230421   # + 1.7e-04
 Unknown_Scale_Factor_cobra = 1.0 - 5.0e-5
@@ -13,10 +15,7 @@ Unknown_Scale_Factor_cobra = 1.0 - 5.0e-5
 wfc_scale_M2POS3_coeff = 1.01546e-4
 
 ### Subaru location
-sbr_lat =   +19.8255
-sbr_lon =  +204.523972222
-sbr_hei = +4163.0
-Lsbr = ac.EarthLocation(lat=sbr_lat,lon=sbr_lon,height=sbr_hei)
+Lsbr = SUBARU.location
 
 ### misc.
 sbr_press  = 620.0

--- a/python/pfs/utils/location.py
+++ b/python/pfs/utils/location.py
@@ -1,0 +1,57 @@
+from dataclasses import dataclass
+
+from astropy import units as u
+from astropy.coordinates import Angle, EarthLocation
+
+
+@dataclass(frozen=True)
+class TelescopeLocation:
+    """A dataclass representing the location of a telescope on Earth.
+
+    This class stores the name, height, latitude, and longitude of a telescope
+    and provides a property to convert these values to an astropy EarthLocation object.
+
+    Note
+    ----
+    Most users should not create an instance of this class but instead use the
+    pre-defined SUBARU instance, i.e. `from pfs.utils.location import SUBARU`.
+
+    Parameters
+    ----------
+    name : str
+        The name of the telescope.
+    height : u.Quantity
+        The height of the telescope above sea level, as an astropy Quantity with
+        units of length (e.g., meters).
+    latitude : Angle
+        The latitude of the telescope, as an astropy Angle.
+    longitude : Angle
+        The longitude of the telescope, as an astropy Angle.
+
+    """
+
+    name: str
+    height: u.Quantity
+    latitude: Angle
+    longitude: Angle
+
+    @property
+    def location(self) -> EarthLocation:
+        """Convert to an astropy EarthLocation object.
+
+        Returns
+        -------
+        EarthLocation
+            An astropy EarthLocation object representing the telescope's position
+            on Earth.
+        """
+        return EarthLocation(lat=self.latitude, lon=self.longitude, height=self.height)
+
+
+# Create an instance for Subaru
+SUBARU = TelescopeLocation(
+    name="Subaru Telescope",
+    height=4163 * u.m,
+    latitude=Angle("+19:49:31.8", unit=u.deg),
+    longitude=Angle("-155:28:33.7", unit=u.deg),
+)

--- a/python/pfs/utils/pfsDesignUtils.py
+++ b/python/pfs/utils/pfsDesignUtils.py
@@ -5,15 +5,15 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pytz
 from astropy import units as u
-from astropy.coordinates import SkyCoord, EarthLocation, AltAz
+from astropy.coordinates import SkyCoord, AltAz
 from astropy.time import Time
 from pfs.datamodel import PfsDesign, FiberStatus, TargetType
 from pfs.datamodel.utils import calculate_pfsDesignId
 from pfs.utils.versions import getVersion
+from pfs.utils.location import SUBARU
 
 __all__ = ["makePfsDesign", "showPfsDesign", "fakeRaDecFromPfiNominal"]
 
-subaru = None  # we'll look it up if we need it
 utcoffset = -10  # UTC -> HST.  No daylight saving to worry about
 fakeRa, fakeDec = 100, -89.
 
@@ -344,11 +344,7 @@ def showPfsDesign(pfsDesigns, date=None, timerange=8, showTime=None, showDesignI
     midnight = Time(f'{date} 00:00:00')  # UTC, damn astropy
     time = midnight + np.linspace(24 - timerange / 2, 24 + timerange / 2, 100) * u.hour
 
-    global subaru
-    if subaru is None:
-        subaru = EarthLocation.of_site('Subaru')
-
-    telstate = AltAz(obstime=time - utcoffset * u.hour, location=subaru)  # AltAz needs UTC
+    telstate = AltAz(obstime=time - utcoffset * u.hour, location=SUBARU.location)  # AltAz needs UTC
 
     xformatter = mdates.DateFormatter('%H:%M')
     plt.gca().xaxis.set_major_formatter(xformatter)


### PR DESCRIPTION
* This creates a generic `TelescopeLocation` dataclass as well as a specific instance of `SUBARU`. Most users should always use the `SUBARU` instance.
* Replace instances of Subaru location with common definition.

Example:

```
from pfs.utils.location import SUBARU

# Has a `location` property that is an `EarthLocation
SUBARU.location
```

@yukimoritani I replaced the instances in your `pfs.utils.coordinates` files but tried to keep the changes minimal. There were also a number of instances specified within comments that I did not change.
